### PR TITLE
Add support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - '2.7'
   - '3.6'
   - '3.7'
+  - '3.8'
+  - '3.9'
 
 install: pip install -e .[tests]
 


### PR DESCRIPTION
Add Python 3.8 and 3.9 to `.travis.yml` and GitHub Actions. Did you consider dropping support for 2.7 (and 3.5)?

In the second commit I added the launch of GitHub Actions for pull requests as well. Might be useful to see the check earlier.