### PR TITLE
Add python and cmake aliases

### DIFF
--- a/lastversion/GitHubRepoSession.py
+++ b/lastversion/GitHubRepoSession.py
@@ -57,7 +57,9 @@ class GitHubRepoSession(ProjectHolder):
         },
         'linux': {'repo': 'torvalds/linux'},
         'kernel': {'repo': 'torvalds/linux'},
-        'openssl': {'repo': 'openssl/openssl'}
+        'openssl': {'repo': 'openssl/openssl'},
+        'python': {'repo': 'python/cpython'},
+        'cmake': {'repo': 'kitware/cmake'},
     }
 
     """


### PR DESCRIPTION
A couple of suggested aliases. (Python won't work until tag-only releases are supported again #63)