### PR TITLE
fix(utils): improve unzip/extract

### DIFF
--- a/src/lastversion/utils.py
+++ b/src/lastversion/utils.py
@@ -322,10 +322,10 @@ def download_file(url, local_filename=None):
     return local_filename
 
 
-def check_if_tar_safe(tar_file) -> bool:
+def check_if_tar_safe(tar_file, to_dir) -> bool:
     """CVE-2007-4559"""
     all_members = tar_file.getmembers()
-    root_dir = Path(all_members[0].path).resolve()
+    root_dir = Path(to_dir).resolve()
     for member in all_members:
         if not Path(member.path).resolve().is_relative_to(root_dir):
             return False
@@ -335,7 +335,7 @@ def check_if_tar_safe(tar_file) -> bool:
 def extract_tar(buffer, to_dir):
     """Extract a tar archive to dir."""
     with tarfile.open(fileobj=buffer, mode="r") as tar_file:
-        if not check_if_tar_safe(tar_file):
+        if not check_if_tar_safe(tar_file, to_dir):
             raise TarPathTraversalException("Attempted Path Traversal in Tar File")
         tar_file.extractall(to_dir)
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -74,7 +74,8 @@ def test_github_extract_wordpress():
         with TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             main(["extract", repo])
-            assert os.path.exists("WordPress-6.3.1")
+            assert os.path.exists("index.php")
+            assert os.path.exists("wp-config-sample.php")
 
 
 def test_github_search_python():

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -74,8 +74,7 @@ def test_github_extract_wordpress():
         with TemporaryDirectory() as tmp_dir:
             os.chdir(tmp_dir)
             main(["extract", repo])
-            assert os.path.exists("index.php")
-            assert os.path.exists("wp-config-sample.php")
+            assert os.path.exists("WordPress-6.3.1")
 
 
 def test_github_search_python():


### PR DESCRIPTION
fix #98

- (breaking change): fix extracting rootless tar.
  - [previous code](https://github.com/lxl66566/lastversion/blob/8e1a477b3972bd426522cc92c4e5798a965a0019/src/lastversion/utils.py#L361-L367) assumes that the tar file has a dir as root (`all_members[0]`), but some tar file has a flat structure without a root dir.
- rewrite tar safety check and extract function
- add zip support
- support extract to specific dir, which is useful for external execution