### PR TITLE
docs: document exit code 4 and rate-limit retry behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,20 @@ than leftmost argument.
 Exit status code `3` is returned when filtering assets of last release yields empty URL set
 (no match)
 
+Exit status code `4` is returned when the API refuses the request and `lastversion` gives up.
+This covers:
+
+- **GitHub/Gitea rate limit exceeded.** When the rate-limit reset window is under 5 minutes
+  away, `lastversion` automatically sleeps until the reset and retries (up to 2 sleeps).
+  If the reset is more than 5 minutes away, or retries are exhausted, it exits `4` rather
+  than blocking your script for a long time. The unauthenticated GitHub quota is 60
+  req/hour, so a fresh quota exhaustion almost always falls into the "no wait, exit 4"
+  branch. Set `GITHUB_API_TOKEN` (see Tips below) to raise the ceiling to 5000 req/hour.
+- Invalid or missing API token (HTTP 401).
+- Semver constraint (`--major`, `--only`, etc.) filtered every release out.
+
+The error message goes to stderr; stdout is empty.
+
 ## Tips
 
 Getting the latest version is heavy on the API, because GitHub does not allow to fetch tags in


### PR DESCRIPTION
## Summary

- Documents exit status code `4`, which already exists in code (`cli.py:185, 634`) but was missing from the README.
- Explains the conditional rate-limit retry in `repo_holders/github.py:239-264`: sleeps + retries when reset window < 5 min, exits `4` otherwise to avoid blocking scripts.
- Notes the practical implication: unauthenticated 60 req/hour quota almost always lands in the "no wait, exit 4" branch, so setting `GITHUB_API_TOKEN` is the real fix.

Closes #233.

## Test plan

- [x] \`git diff README.md\` shows only the Exit Status codes section changed.
- [ ] Render README on GitHub to confirm formatting.
- No code changed, so test suite untouched.